### PR TITLE
suppress build warnings of jekyll 2.3

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 title : Atom Feed
 ---
 <?xml version="1.0" encoding="utf-8"?>

--- a/rss.xml
+++ b/rss.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 title : RSS Feed
 ---
 


### PR DESCRIPTION
jekyll 2.3 changed yaml semantics, which introduces build warning for older configurations

```
  $ sudo docker logs james_blog

  Configuration file: /data/_config.yml
              Source: /data
         Destination: /var/www/html
        Generating...
       Build Warning: Layout 'nil' requested in atom.xml does not exist.
       Build Warning: Layout 'nil' requested in rss.xml does not exist.
```

see jekyll/jekyll#2712 for details
