### PR TITLE
Use layout: null instead of nil in feed templates

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,10 +1,10 @@
 ---
-layout: nil
+layout: null
 title : Atom Feed
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
- 
+
  <title>{{ site.title }}</title>
  <link href="{{ site.production_url }}/{{ site.atom_path }}" rel="self"/>
  <link href="{{ site.production_url }}"/>
@@ -24,5 +24,5 @@ title : Atom Feed
    <content type="html">{{ post.content | xml_escape }}</content>
  </entry>
  {% endfor %}
- 
+
 </feed>

--- a/rss.xml
+++ b/rss.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 title : RSS Feed
 ---
 


### PR DESCRIPTION
Jekyll does not accept `layout: nil` in atom.xml and rss.xml any more. Changed it to `null`.